### PR TITLE
BUG: fixed importing of Bluesky's mv

### DIFF
--- a/isstools/batch/table_batch.py
+++ b/isstools/batch/table_batch.py
@@ -5,7 +5,7 @@ import numpy as np
 from isstools.trajectory.trajectory import trajectory, trajectory_manager
 from isstools.conversions import xray
 from subprocess import call
-from bluesky.plans import mv
+from bluesky.plan_stubs import mv
 
 
 class XASExperiment:


### PR DESCRIPTION
This was observed while working on the tests for the recipe of `qastools` (see https://github.com/NSLS-II/lightsource2-recipes/pull/648).

@lcdesilva, we should tag a new version and rebuild it once it's merged.